### PR TITLE
Added forge tests for Controllers and Calls

### DIFF
--- a/contracts/modules/Calls/Calls.sol
+++ b/contracts/modules/Calls/Calls.sol
@@ -9,10 +9,20 @@
 
 pragma solidity 0.8.18;
 
-import "./ICalls.sol";
-import "../Controllers/Controllers.sol";
+import { Initializable } from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
+import { ICalls, CallsStructs } from "./ICalls.sol";
+import { Controllers } from "../Controllers/Controllers.sol";
 
-contract Calls is ICalls, Controllers {
+abstract contract Calls is ICalls, Initializable, Controllers {
+
+  constructor() {
+    _disableInitializers();
+  }
+
+  function __Calls_init(address _controller) internal onlyInitializing {
+    __Controllers_init(_controller);
+  }
+
   function call(
     CallsStructs.CallRequest calldata _callRequest,
     bytes[] calldata _signatures

--- a/contracts/modules/ERC1271/ERC1271.sol
+++ b/contracts/modules/ERC1271/ERC1271.sol
@@ -47,7 +47,7 @@ abstract contract ERC1271 is IERC1271, Controllers {
         signatures[i] = _signature.slice(i * SIGNATURE_BYTES_LENGTH, SIGNATURE_BYTES_LENGTH);
       }
       
-      (bool verified, ) = verifyControllersThresholdBySignatures(_hash, signatures);
+      (bool verified, ) = _verifyControllersThresholdBySignatures(_hash, signatures);
 
       return verified;
     }

--- a/contracts/modules/Main/Main.sol
+++ b/contracts/modules/Main/Main.sol
@@ -9,22 +9,22 @@
 
 pragma solidity 0.8.18;
 
-import "../Calls/Calls.sol";
-import "../Controllers/Controllers.sol";
-import "../ERC1271/ERC1271.sol";
-import "../Hooks/Hooks.sol";
-import "../Upgrades/Upgrades.sol";
-import "../PreauthorizedCalls/PreauthorizedCalls.sol";
-import "./MainStorage.sol";
-import "./IMain.sol";
+import { Initializable } from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
+import { Calls } from "../Calls/Calls.sol";
+import { Controllers } from "../Controllers/Controllers.sol";
+import { ERC1271 } from "../ERC1271/ERC1271.sol";
+import { Versioned } from "../Versioned/Versioned.sol";
+import { Hooks } from "../Hooks/Hooks.sol";
+import { Upgrades } from "../Upgrades/Upgrades.sol";
+import { PreauthorizedCalls } from "../PreauthorizedCalls/PreauthorizedCalls.sol";
+import { MainStorage } from "./MainStorage.sol";
+import { IMain } from "./IMain.sol";
 
-contract Main is IMain, PreauthorizedCalls, Hooks, Upgrades, ERC1271 {
+contract Main is IMain, Initializable, Versioned, PreauthorizedCalls, Hooks, Upgrades, ERC1271 {
   string public constant version = "alpha-1.0.0";
 
-  function initialize(address _controller) external {
-    require(!MainStorage.layout().initialized, "Already initialized");
-    _addController(_controller, 1);
-    MainStorage.layout().initialized = true;
+  function initialize(address _controller) external initializer {
+    __Controllers_init(_controller);
   }
 
   function supportsInterface(

--- a/contracts/modules/Main/MainStorage.sol
+++ b/contracts/modules/Main/MainStorage.sol
@@ -13,7 +13,7 @@ library MainStorage {
   bytes32 private constant STORAGE_SLOT = keccak256("com.trymetafab.wallet.Main");
 
   struct Layout {
-    bool initialized;
+    uint256 __placeholder;
   }
 
   function layout() internal pure returns (Layout storage _layout) {

--- a/contracts/modules/Versioned/Versioned.sol
+++ b/contracts/modules/Versioned/Versioned.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Commons-Clause-1.0
+//  __  __     _        ___     _
+// |  \/  |___| |_ __ _| __|_ _| |__
+// | |\/| / -_)  _/ _` | _/ _` | '_ \
+// |_|  |_\___|\__\__,_|_|\__,_|_.__/
+//
+// Launch your crypto game or gamefi project's blockchain
+// infrastructure & game APIs fast with https://trymetafab.com
+
+pragma solidity 0.8.18;
+
+import { Initializable } from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
+
+abstract contract Versioned is Initializable {
+    constructor() {
+        _disableInitializers();
+    }
+
+    function __Versioned_init() internal onlyInitializing { }
+
+    function getCurrentVersion() external view returns (uint256) {
+        return Initializable._getInitializedVersion();
+    }
+}

--- a/foundry.toml
+++ b/foundry.toml
@@ -18,6 +18,10 @@ mainnet = { key = "${ETHERSCAN_KEY}", chain = 1 }
 polygon = { key = "${POLYSCAN_KEY}", chain = 137 }
 mumbai = { key = "${POLYSCAN_KEY}", chain = 80001 }
 
+[fmt]
+multiline_func_header = "params_first"
+bracket_spacing = true
+
 [doc]
 out = '.docs'
 repository = '_'

--- a/test/forge/Calls.t.sol
+++ b/test/forge/Calls.t.sol
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity ^0.8.0;
+
+import { TestBase } from "./utils/TestBase.sol";
+
+import { Calls, CallsStructs } from "contracts/modules/Calls/Calls.sol";
+
+import "forge-std/console.sol";
+
+contract CallsImpl is Calls {
+    bool public didSomething;
+
+    function initialize(address _controller) public initializer {
+        __Calls_init(_controller);
+    }
+}
+
+contract Counter {
+    uint256 public count;
+
+    function increment(uint256 _amount) public {
+        count += _amount;
+    }
+}
+
+contract CallsTest is TestBase {
+    CallsImpl _calls;
+    Counter _counter;
+
+    function setUp() public {
+        _calls = CallsImpl(proxify(address(new CallsImpl())));
+        _calls.initialize(signingAuthority);
+        _counter = new Counter();
+    }
+
+    function testCallsRequireThreshold() public {
+        CallsStructs.CallRequest[] memory _callReqs = new CallsStructs.CallRequest[](1);
+        CallsStructs.CallRequest memory _callReq = CallsStructs.CallRequest({
+            target: address(this),
+            value: 1,
+            data: new bytes(0),
+            nonce: 1
+        });
+        _callReqs[0] = _callReq;
+
+        vm.expectRevert("Signer weights does not meet threshold");
+        _calls.call(_callReq, new bytes[](0));
+
+        vm.expectRevert("Signer weights does not meet threshold");
+        _calls.multiCall(_callReqs, new bytes[](0));
+    }
+
+    function testAllowTransferFundsWithConsensus() public {
+        vm.deal(address(_calls), 3 ether);
+        CallsStructs.CallRequest memory _callReq = CallsStructs.CallRequest({
+            target: leet,
+            value: 1 ether,
+            data: "",
+            nonce: 1
+        });
+        assertEq(3 ether, address(_calls).balance);
+        assertEq(0, leet.balance);
+
+        _calls.call(_callReq, arraySingle(signHashAsMessage(signingPK, keccak256(abi.encode(_callReq, block.chainid)))));
+
+        vm.expectRevert("At least one signature already used");
+        _calls.call(_callReq, arraySingle(signHashAsMessage(signingPK, keccak256(abi.encode(_callReq, block.chainid)))));
+
+        assertEq(2 ether, address(_calls).balance);
+        assertEq(1 ether, leet.balance);
+
+        CallsStructs.CallRequest[] memory _callReqs = new CallsStructs.CallRequest[](2);
+        _callReqs[0] = _callReq;
+        _callReqs[1] = CallsStructs.CallRequest({
+            target: alice,
+            value: 0.5 ether,
+            data: "",
+            nonce: 1
+        });
+        assertEq(0, alice.balance);
+
+        _calls.multiCall(_callReqs, arraySingle(signHashAsMessage(signingPK, keccak256(abi.encode(_callReqs, block.chainid)))));
+
+        vm.expectRevert("At least one signature already used");
+        _calls.multiCall(_callReqs, arraySingle(signHashAsMessage(signingPK, keccak256(abi.encode(_callReqs, block.chainid)))));
+
+        assertEq(0.5 ether, address(_calls).balance);
+        assertEq(2 ether, leet.balance);
+        assertEq(0.5 ether, alice.balance);
+    }
+
+    function testAllowContractCallsWithConsensus() public {
+        CallsStructs.CallRequest memory _callReq = CallsStructs.CallRequest({
+            target: address(_counter),
+            value: 0,
+            data: abi.encodeWithSelector(Counter.increment.selector, 1),
+            nonce: 1
+        });
+        assertEq(0, _counter.count());
+
+        _calls.call(_callReq, arraySingle(signHashAsMessage(signingPK, keccak256(abi.encode(_callReq, block.chainid)))));
+
+        vm.expectRevert("At least one signature already used");
+        _calls.call(_callReq, arraySingle(signHashAsMessage(signingPK, keccak256(abi.encode(_callReq, block.chainid)))));
+
+        assertEq(1, _counter.count());
+
+        CallsStructs.CallRequest[] memory _callReqs = new CallsStructs.CallRequest[](2);
+        _callReqs[0] = _callReq;
+        _callReqs[1] = CallsStructs.CallRequest({
+            target: address(_counter),
+            value: 0,
+            data: abi.encodeWithSelector(Counter.increment.selector, 8),
+            nonce: 2
+        });
+
+        _calls.multiCall(_callReqs, arraySingle(signHashAsMessage(signingPK, keccak256(abi.encode(_callReqs, block.chainid)))));
+
+        vm.expectRevert("At least one signature already used");
+        _calls.multiCall(_callReqs, arraySingle(signHashAsMessage(signingPK, keccak256(abi.encode(_callReqs, block.chainid)))));
+
+        assertEq(10, _counter.count());
+    }
+
+    function testAllowMixedCallsWithConsensus() public {
+        vm.deal(address(_calls), 3 ether);
+
+        CallsStructs.CallRequest[] memory _callReqs = new CallsStructs.CallRequest[](3);
+        _callReqs[0] = CallsStructs.CallRequest({
+            target: leet,
+            value: 1 ether,
+            data: "",
+            nonce: 1
+        });
+        _callReqs[1] = CallsStructs.CallRequest({
+            target: address(_counter),
+            value: 0,
+            data: abi.encodeWithSelector(Counter.increment.selector, 100),
+            nonce: 1
+        });
+        _callReqs[2] = CallsStructs.CallRequest({
+            target: alice,
+            value: 1 ether,
+            data: "",
+            nonce: 1
+        });
+        assertEq(3 ether, address(_calls).balance);
+        assertEq(0, alice.balance);
+        assertEq(0, leet.balance);
+
+        _calls.multiCall(_callReqs, arraySingle(signHashAsMessage(signingPK, keccak256(abi.encode(_callReqs, block.chainid)))));
+
+        assertEq(1 ether, address(_calls).balance);
+        assertEq(1 ether, leet.balance);
+        assertEq(1 ether, alice.balance);
+        assertEq(100, _counter.count());
+
+        vm.expectRevert("At least one signature already used");
+        _calls.multiCall(_callReqs, arraySingle(signHashAsMessage(signingPK, keccak256(abi.encode(_callReqs, block.chainid)))));
+    }
+}

--- a/test/forge/Controllers.t.sol
+++ b/test/forge/Controllers.t.sol
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity ^0.8.0;
+
+import { TestBase } from "./utils/TestBase.sol";
+import { Controllers, ControllersStorage } from "contracts/modules/Controllers/Controllers.sol";
+
+import "forge-std/console.sol";
+
+contract ControllersImpl is Controllers {
+    bool public didSomething;
+
+    function initialize(address _controller) public initializer {
+        __Controllers_init(_controller);
+    }
+
+    function doSomethingWithConsensus(bytes[] calldata _signatures)
+        external
+        meetsControllersThreshold(keccak256(abi.encode(block.chainid)), _signatures)
+    {
+        didSomething = true;
+    }
+}
+
+contract ControllersTest is TestBase {
+    ControllersImpl _controllers;
+
+    uint256 internal defaultControllerWeight = 1;
+    uint256 internal defaultThreshold = 1;
+    uint256 internal defaultNonce = 1;
+    uint256 internal nonceCur = 2;
+
+    function setUp() public {
+        _controllers = ControllersImpl(proxify(address(new ControllersImpl())));
+        _controllers.initialize(signingAuthority);
+    }
+
+    function _addController(address _addr) internal{
+        bytes memory sig = signHashAsMessage(signingPK, keccak256(abi.encode(arraySingle(_addr), arraySingle(defaultControllerWeight), ++nonceCur, block.chainid)));
+        _controllers.addControllers(arraySingle(_addr), arraySingle(defaultControllerWeight), nonceCur, arraySingle(sig));
+    }
+
+    function testRevertRunTxWithoutControllersOrThresholds() public {
+        ControllersImpl controller = ControllersImpl(proxify(address(new ControllersImpl())));
+        vm.expectRevert("Controllers not initialized");
+        controller.doSomethingWithConsensus(new bytes[](0));
+        vm.expectRevert("Controllers not initialized");
+        controller.updateControlThreshold(defaultThreshold, 0, new bytes[](0));
+        vm.expectRevert("Controllers not initialized");
+        controller.addControllers(arraySingle(deployer), arraySingle(defaultControllerWeight), defaultNonce, new bytes[](0));
+    }
+
+    function testRevertRunTxWithoutControllerConsensus() public {
+        vm.expectRevert("Signer weights does not meet threshold");
+        _controllers.doSomethingWithConsensus(new bytes[](0));
+    }
+
+    function testAllowRunTxWithControllerConsensus() public {
+        bytes memory sig = signHashAsMessage(signingPK, keccak256(abi.encode(block.chainid)));
+        _controllers.doSomethingWithConsensus(arraySingle(sig));
+
+        assertTrue(_controllers.didSomething());
+    }
+
+    function testAllowRunTxConsensusExtraControllers() public {
+        _addController(deployer);
+        bytes memory sig = signHashAsMessage(signingPK, keccak256(abi.encode(block.chainid)));
+        _controllers.doSomethingWithConsensus(arraySingle(sig));
+
+        assertTrue(_controllers.didSomething());
+    }
+
+    function testRevertRunTxPartialConsensus() public {
+        _addController(deployer);
+        bytes memory sigThreshold = signHashAsMessage(signingPK, keccak256(abi.encode(defaultThreshold + 1, ++nonceCur, block.chainid)));
+        _controllers.updateControlThreshold(defaultThreshold + 1, nonceCur, arraySingle(sigThreshold));
+        bytes memory sig = signHashAsMessage(signingPK, keccak256(abi.encode(block.chainid)));
+
+        vm.expectRevert("Signer weights does not meet threshold");
+        _controllers.doSomethingWithConsensus(arraySingle(sig));
+    }
+
+    function testAllowRemoveController() public {
+        _addController(deployer);
+        bytes memory sig = signHashAsMessage(signingPK, keccak256(abi.encode(arraySingle(deployer), defaultNonce, block.chainid)));
+
+        assertEq(1, _controllers.controllerWeight(deployer));
+
+        _controllers.removeControllers(arraySingle(deployer), defaultNonce, arraySingle(sig));
+
+        assertEq(0, _controllers.controllerWeight(deployer));
+    }
+
+    function testAllowUpdateControllerWeight() public {
+        uint256 newWeight = 2;
+        _addController(deployer);
+        uint256 totalWeight = _controllers.controllersTotalWeight();
+        bytes memory sig = signHashAsMessage(signingPK, keccak256(abi.encode(deployer, newWeight, defaultNonce, block.chainid)));
+
+        assertEq(defaultControllerWeight, _controllers.controllerWeight(deployer));
+
+        _controllers.updateControllerWeight(deployer, newWeight, defaultNonce, arraySingle(sig));
+
+        assertEq(newWeight, _controllers.controllerWeight(deployer));
+        assertEq(totalWeight + (newWeight - defaultControllerWeight), _controllers.controllersTotalWeight());
+    }
+
+    function testRevertReusingSig() public {
+        _addController(deployer);
+        bytes memory sig = signHashAsMessage(signingPK, keccak256(abi.encode(block.chainid)));
+
+        _controllers.doSomethingWithConsensus(arraySingle(sig));
+
+        vm.expectRevert("At least one signature already used");
+        _controllers.doSomethingWithConsensus(arraySingle(sig));
+    }
+
+    function testControllerThresholdsEqualWeightsFuzz(uint _numControllers, uint _threshold) public {
+        vm.assume(_numControllers > 0 && _numControllers <= 6);
+        vm.assume(_threshold > 0 && _threshold <= _numControllers);
+        uint256 pkOffset = 100;
+
+        for (uint i = 0; i < _numControllers; i++) {
+            _addController(vm.addr(i + pkOffset));
+        }
+
+        bytes memory sigThreshold = signHashAsMessage(signingPK, keccak256(abi.encode(_threshold, ++nonceCur, block.chainid)));
+        _controllers.updateControlThreshold(_threshold, nonceCur, arraySingle(sigThreshold));
+
+        bytes[] memory sigs = new bytes[](_threshold);
+
+        for (uint i = 0; i < _threshold; i++) {
+            sigs[i] = signHashAsMessage(i + pkOffset, keccak256(abi.encode(block.chainid)));
+        }
+
+        _controllers.doSomethingWithConsensus(sigs);
+    }
+}

--- a/test/forge/SessionCalls.t.sol
+++ b/test/forge/SessionCalls.t.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity ^0.8.0;
+
+import { TestBase } from "./utils/TestBase.sol";
+import { SessionCalls } from "contracts/modules/SessionCalls/SessionCalls.sol";
+
+import "forge-std/console.sol";
+
+contract SessionCallsTest is TestBase {
+
+    function setUp() public {
+    }
+
+    function testStartSession() public { }
+}

--- a/test/forge/utils/TestBase.sol
+++ b/test/forge/utils/TestBase.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity ^0.8.0;
+
+import { Test } from "forge-std/Test.sol";
+import { TestUtilities } from "./TestUtilities.sol";
+import { TestErrors } from "./TestErrors.sol";
+import { TestLogging } from "./TestLogging.sol";
+import { TestProxyUtilities } from "./TestProxyUtilities.sol";
+
+abstract contract TestBase is Test, TestUtilities, TestErrors, TestLogging, TestProxyUtilities {
+    address internal leet = address(0x1337);
+    address internal alice = address(0xa11ce);
+    address internal deployer = address(this);
+
+    uint256 internal signingPK = 1;
+    address internal signingAuthority = vm.addr(signingPK);
+
+    constructor() {
+        vm.label(leet, "L33T");
+        vm.label(alice, "Alice");
+        vm.label(deployer, "Deployer");
+    }
+}

--- a/test/forge/utils/TestErrors.sol
+++ b/test/forge/utils/TestErrors.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity ^0.8.0;
+
+abstract contract TestErrors {
+    function err(bytes4 selector) internal pure returns (bytes memory) {
+        return abi.encodeWithSelector(selector);
+    }
+
+    function err(bytes4 selector, address arg1) internal pure returns (bytes memory) {
+        return abi.encodeWithSelector(selector, arg1);
+    }
+
+    function err(bytes4 selector, uint256 arg1) internal pure returns (bytes memory) {
+        return abi.encodeWithSelector(selector, arg1);
+    }
+
+    function err(bytes4 selector, bytes32 arg1) internal pure returns (bytes memory) {
+        return abi.encodeWithSelector(selector, arg1);
+    }
+
+    function err(bytes4 selector, address arg1, address arg2) internal pure returns (bytes memory) {
+        return abi.encodeWithSelector(selector, arg1, arg2);
+    }
+
+    function err(bytes4 selector, address arg1, bytes memory arg2) internal pure returns (bytes memory) {
+        return abi.encodeWithSelector(selector, arg1, arg2);
+    }
+
+    function err(bytes4 selector, address arg1, uint256 arg2) internal pure returns (bytes memory) {
+        return abi.encodeWithSelector(selector, arg1, arg2);
+    }
+
+    function err(bytes4 selector, uint256 arg1, address arg2) internal pure returns (bytes memory) {
+        return abi.encodeWithSelector(selector, arg1, arg2);
+    }
+
+    function err(bytes4 selector, bytes32 arg1, address arg2) internal pure returns (bytes memory) {
+        return abi.encodeWithSelector(selector, arg1, arg2);
+    }
+
+    function err(bytes4 selector, bytes32 arg1, bytes32 arg2) internal pure returns (bytes memory) {
+        return abi.encodeWithSelector(selector, arg1, arg2);
+    }
+
+    function err(bytes4 selector, uint256 arg1, uint256 arg2) internal pure returns (bytes memory) {
+        return abi.encodeWithSelector(selector, arg1, arg2);
+    }
+
+    function err(bytes4 selector, bytes32 arg1, uint256 arg2) internal pure returns (bytes memory) {
+        return abi.encodeWithSelector(selector, arg1, arg2);
+    }
+
+    function err(bytes4 selector, uint256 arg1, uint256 arg2, address arg3) internal pure returns (bytes memory) {
+        return abi.encodeWithSelector(selector, arg1, arg2, arg3);
+    }
+
+    function err(bytes4 selector, bytes32 arg1, uint256 arg2, address arg3) internal pure returns (bytes memory) {
+        return abi.encodeWithSelector(selector, arg1, arg2, arg3);
+    }
+}

--- a/test/forge/utils/TestLogging.sol
+++ b/test/forge/utils/TestLogging.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity ^0.8.0;
+
+import { console } from "forge-std/console.sol";
+
+abstract contract TestLogging {
+    function debug(uint256 p0) internal view {
+        console.log(p0);
+    }
+
+    function debug(string memory p0) internal view {
+        console.log(p0);
+    }
+
+    function debug(bool p0) internal view {
+        console.log(p0);
+    }
+
+    function debug(string memory label, bool p0) internal view {
+        console.log(label, p0);
+    }
+
+    function debug(address p0) internal view {
+        console.log(p0);
+    }
+
+    function debug(string memory label, address p0) internal view {
+        console.log(label, p0);
+    }
+
+    function debug(int256 p0) internal view {
+        console.logInt(p0);
+    }
+
+    function debugBytes(bytes memory p0) internal view {
+        console.logBytes(p0);
+    }
+
+    function debugBytes32(bytes32 p0) internal view {
+        console.logBytes32(p0);
+    }
+}

--- a/test/forge/utils/TestProxyUtilities.sol
+++ b/test/forge/utils/TestProxyUtilities.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity ^0.8.0;
+
+import { Clones } from "@openzeppelin/contracts/proxy/Clones.sol";
+
+abstract contract TestProxyUtilities {
+
+    function proxify(address implementation) internal returns (address proxy) {
+        proxy = Clones.clone(implementation);
+    }
+}

--- a/test/forge/utils/TestUtilities.sol
+++ b/test/forge/utils/TestUtilities.sol
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity ^0.8.0;
+
+import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
+import { ECDSA } from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+
+import { Test } from "forge-std/Test.sol";
+
+abstract contract TestUtilities is Test {
+    using ECDSA for bytes32;
+    using Strings for uint256;
+
+    // Hex representation of 0123456789abcdef used for character lookup
+    bytes32 internal constant ALPHANUMERIC_HEX = 0x3031323334353637383961626364656600000000000000000000000000000000;
+
+    function arraySingle(address _addr) internal pure returns (address[] memory) {
+        address[] memory arr = new address[](1);
+        arr[0] = _addr;
+        return arr;
+    }
+    
+    function arraySingle(uint256 _val) internal pure returns (uint256[] memory) {
+        uint256[] memory arr = new uint256[](1);
+        arr[0] = _val;
+        return arr;
+    }
+
+    function arraySingle(bytes memory _val) internal pure returns (bytes[] memory) {
+        bytes[] memory arr = new bytes[](1);
+        arr[0] = _val;
+        return arr;
+    }
+
+    function toString(uint256 _val) internal pure returns (string memory) {
+        return _val.toString();
+    }
+
+    function roleBytes(string memory _roleName) public pure returns (bytes32) {
+        return keccak256(abi.encodePacked(_roleName));
+    }
+
+    function namehash(bytes memory domain) internal pure returns (bytes32) {
+        return namehash(domain, 0);
+    }
+
+    function namehash(bytes memory domain, uint256 i) internal pure returns (bytes32) {
+        if (domain.length <= i) {
+            return 0x0000000000000000000000000000000000000000000000000000000000000000;
+        }
+
+        uint256 len = labelLength(domain, i);
+
+        return keccak256(abi.encodePacked(namehash(domain, i + len + 1), keccak(domain, i, len)));
+    }
+
+    function labelLength(bytes memory domain, uint256 i) private pure returns (uint256) {
+        uint256 len;
+        while (i + len != domain.length && domain[i + len] != 0x2e) {
+            len++;
+        }
+        return len;
+    }
+
+    function keccak(bytes memory data, uint256 offset, uint256 len) private pure returns (bytes32 ret) {
+        require(offset + len <= data.length);
+        assembly {
+            ret := keccak256(add(add(data, 32), offset), len)
+        }
+    }
+
+    // Taken from AddressResolver for tests
+    function addressToBytes(address a) internal pure returns (bytes memory b) {
+        b = new bytes(20);
+        assembly {
+            mstore(add(b, 32), mul(a, exp(256, 12)))
+        }
+    }
+
+    // Taken from AddressResolver for tests
+    function bytesToAddress(bytes memory b) internal pure returns (address payable a) {
+        require(b.length == 20);
+        assembly {
+            a := div(mload(add(b, 32)), exp(256, 12))
+        }
+    }
+
+    /**
+     * @dev An optimised function to compute the sha3 of the lower-case
+     *      hexadecimal representation of an Ethereum address.
+     * @param addr The address to hash
+     * @return ret The SHA3 hash of the lower-case hexadecimal encoding of the
+     *         input address.
+     */
+    function sha3HexAddress(address addr) internal pure returns (bytes32 ret) {
+        assembly {
+            for { let i := 40 } gt(i, 0) { } {
+                i := sub(i, 1)
+                mstore8(i, byte(and(addr, 0xf), ALPHANUMERIC_HEX))
+                addr := div(addr, 0x10)
+                i := sub(i, 1)
+                mstore8(i, byte(and(addr, 0xf), ALPHANUMERIC_HEX))
+                addr := div(addr, 0x10)
+            }
+
+            ret := keccak256(0, 40)
+        }
+    }
+
+    /**
+     * @dev Returns the domain separator for the current chain.
+     */
+    function _domainSeparatorV4(
+        bytes memory _domainName,
+        bytes memory _domainVersion,
+        address _receivingContractAddress
+    ) internal view returns (bytes32) {
+        // Hardcoded name+version to the current version of the forwarder
+        // Must pass in the address of the receiving contract because they will build the domain separator
+        //  with their address
+        return _buildDomainSeparator(
+            keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
+            keccak256(_domainName),
+            keccak256(_domainVersion),
+            _receivingContractAddress
+        );
+    }
+
+    function _buildDomainSeparator(
+        bytes32 typeHash,
+        bytes32 nameHash,
+        bytes32 versionHash,
+        address _receivingContractAddress
+    ) private view returns (bytes32) {
+        return keccak256(abi.encode(typeHash, nameHash, versionHash, block.chainid, _receivingContractAddress));
+    }
+
+    /**
+     * @dev Given an already https://eips.ethereum.org/EIPS/eip-712#definition-of-hashstruct[hashed struct], this
+     * function returns the hash of the fully encoded EIP712 message for this domain.
+     *
+     * This hash can be used together with {ECDSA-recover} to obtain the signer of a message. For example:
+     *
+     * ```solidity
+     * bytes32 digest = _hashTypedDataV4(keccak256(abi.encode(
+     *     keccak256("Mail(address to,string contents)"),
+     *     mailTo,
+     *     keccak256(bytes(mailContents))
+     * )));
+     * address signer = ECDSA.recover(digest, signature);
+     * ```
+     */
+    function _hashTypedDataV4(
+        bytes32 _structHash,
+        bytes memory _domainName,
+        bytes memory _domainVersion,
+        address _receivingContractAddress
+    ) internal view virtual returns (bytes32) {
+        return ECDSA.toTypedDataHash(
+            _domainSeparatorV4(_domainName, _domainVersion, _receivingContractAddress), _structHash
+        );
+    }
+
+    function signHash(uint256 privateKey, bytes32 digest) internal pure returns (bytes memory bytes_) {
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, digest);
+        // convert curve to sig bytes for using with ECDSA vs ecrecover
+        bytes_ = abi.encodePacked(r, s, v);
+    }
+
+    function signHashAsMessage(uint256 privateKey, bytes32 digest) internal pure returns (bytes memory bytes_) {
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, digest.toEthSignedMessageHash());
+        // convert curve to sig bytes for using with ECDSA vs ecrecover
+        bytes_ = abi.encodePacked(r, s, v);
+    }
+
+    function signHashVRS(uint256 privateKey, bytes32 digest) internal pure returns (uint8 v, bytes32 r, bytes32 s) {
+        (v, r, s) = vm.sign(privateKey, digest);
+    }
+
+    function signHashEth(uint256 privateKey, bytes32 digest) internal pure returns (bytes memory bytes_) {
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, ECDSA.toEthSignedMessageHash(digest));
+        // convert curve to sig bytes for using with ECDSA vs ecrecover
+        bytes_ = abi.encodePacked(r, s, v);
+    }
+
+    function signHashEthVRS(uint256 privateKey, bytes32 digest) internal pure returns (uint8 v, bytes32 r, bytes32 s) {
+        (v, r, s) = vm.sign(privateKey, ECDSA.toEthSignedMessageHash(digest));
+    }
+}


### PR DESCRIPTION
Also added:
- Versioned contract for getting a proxy's current initialized version
- Initializable contracts across the tested contracts
- Controllers requires the _init contract to be called before using any functions
- Forge fmt settings added for linting (to be done)
- Explicit imports for the tested contracts