### PR TITLE
feat: erc1155 session allowances + tests + session contract refactor

### DIFF
--- a/contracts/modules/SessionCalls/SessionCallsStorage.sol
+++ b/contracts/modules/SessionCalls/SessionCallsStorage.sol
@@ -14,11 +14,21 @@ import "./SessionCallsStructs.sol";
 library SessionCallsStorage {
     bytes32 private constant STORAGE_SLOT = keccak256("com.trymetafab.wallet.SessionCalls");
 
+    struct FunctionInfo {
+        /**
+         * @dev Whether or not the function is a transfer function.
+         */
+        bool isTransfer;
+        /**
+         * @dev The number of bits in the calldata preceding the token ID.
+         *  This does not include the function selector.
+         */
+        uint16 tokenIdCalldataBitOffset;
+    }
+
     struct Layout {
         mapping(address => mapping(uint256 => SessionCallsStructs.Session)) sessions;
         mapping(address => uint256) nextSessionId;
-        mapping(bytes4 => bool) isRestrictedFunction;
-        mapping(bytes4 => bool) isERC20TransferFunction;
     }
 
     function layout() internal pure returns (Layout storage _layout) {
@@ -28,4 +38,14 @@ library SessionCallsStorage {
             _layout.slot := slot
         }
     }
+
+    error InsufficientNativeTokenAllowance(uint256 amount, uint256 allowance);
+    error SessionExpired();
+    error NoSessionStarted(address sender);
+    error UnauthorizedSessionCall(address targetContract, bytes4 functionSelector);
+    error InvalidERC20TransferFunctionSelector(bytes4 functionSelector);
+    error UnknownERC1155TransferFunction(bytes4 functionSelector);
+    error InvalidStartingERC20BalancesLength(uint256 startingFungibleTokenBalancesLength);
+    error InsufficientAllowanceForERC1155Transfer(address tokenAddress, uint256 tokenId, uint256 amount, uint256 allowance);
+    error InsufficientAllowanceForERC20Transfer(address tokenAddress, uint256 amount, uint256 allowance);
 }

--- a/test/forge/mocks/ERC1155Mock.sol
+++ b/test/forge/mocks/ERC1155Mock.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import { ERC1155 } from "@openzeppelin/contracts/token/ERC1155/ERC1155.sol";
+
+/// @title ERC1155MockDecimals
+/// @dev ONLY FOR TESTS
+contract ERC1155Mock is ERC1155 {
+    constructor() ERC1155("www.example.come") { }
+
+    /// @dev Mint _amount to _to.
+    /// @param _to The address that will receive the mint
+    /// @param _amount The amount to be minted
+    function mint(address _to, uint256 _tokenId, uint256 _amount) external {
+        _mint(_to, _tokenId, _amount, "");
+    }
+
+    /**
+     * @dev needed to reference function selector as ERC1155Mock.safeTransferFrom.selector
+     */
+    function safeTransferFrom(
+        address from,
+        address to,
+        uint256 id,
+        uint256 amount,
+        bytes memory data
+    ) public virtual override {
+        super.safeTransferFrom(from, to, id, amount, data);
+    }
+
+    /**
+     * @dev needed to reference function selector as ERC1155Mock.safeBatchTransferFrom.selector
+     */
+    function safeBatchTransferFrom(
+        address _from,
+        address _to,
+        uint256[] memory _ids,
+        uint256[] memory _amounts,
+        bytes memory _data
+    ) public override {
+        super.safeBatchTransferFrom(_from, _to, _ids, _amounts, _data);
+    }
+
+    /**
+     * @dev needed to reference function selector as ERC1155Mock.setApprovalForAll.selector
+     */
+    function setApprovalForAll(address operator, bool approved) public virtual override {
+        super.setApprovalForAll(operator, approved);
+    }
+}

--- a/test/forge/utils/TestSessionUtilities.sol
+++ b/test/forge/utils/TestSessionUtilities.sol
@@ -16,13 +16,13 @@ abstract contract TestSessionUtilities is TestUtilities {
         });
     }
 
-    function createRestrictedSessionRequest(address sessionContract, bytes4 functionSelector) internal pure returns (SessionCallsStructs.SessionRequest memory) {
+    function createRestrictedSessionRequest(address _sessionContract, bytes4 _functionSelector) internal pure returns (SessionCallsStructs.SessionRequest memory) {
         SessionCallsStructs.SessionRequest_ContractFunctionSelectors[] memory selectors =
             new SessionCallsStructs.SessionRequest_ContractFunctionSelectors[](1);
         bytes4[] memory functions = new bytes4[](1);
-        functions[0] = functionSelector;
+        functions[0] = _functionSelector;
         selectors[0] = SessionCallsStructs.SessionRequest_ContractFunctionSelectors({
-            aContract: sessionContract,
+            aContract: _sessionContract,
             functionSelectors: functions
         });
         return SessionCallsStructs.SessionRequest({
@@ -34,17 +34,17 @@ abstract contract TestSessionUtilities is TestUtilities {
         });
     }
 
-    function createGasSpendSessionRequest(uint amount, address sessionContract, bytes4 functionSelector) internal pure returns (SessionCallsStructs.SessionRequest memory) {
+    function createGasSpendSessionRequest(uint _amount, address _sessionContract, bytes4 _functionSelector) internal pure returns (SessionCallsStructs.SessionRequest memory) {
         SessionCallsStructs.SessionRequest_ContractFunctionSelectors[] memory selectors =
             new SessionCallsStructs.SessionRequest_ContractFunctionSelectors[](1);
         bytes4[] memory functions = new bytes4[](1);
-        functions[0] = functionSelector;
+        functions[0] = _functionSelector;
         selectors[0] = SessionCallsStructs.SessionRequest_ContractFunctionSelectors({
-            aContract: sessionContract,
+            aContract: _sessionContract,
             functionSelectors: functions
         });
         return SessionCallsStructs.SessionRequest({
-            nativeAllowance: amount,
+            nativeAllowance: _amount,
             contractFunctionSelectors: selectors,
             erc20Allowances: new SessionCallsStructs.SessionRequest_ERC20Allowance[](0),
             erc721Allowances: new SessionCallsStructs.SessionRequest_ERC721Allowance[](0),
@@ -52,20 +52,20 @@ abstract contract TestSessionUtilities is TestUtilities {
         });
     }
 
-    function createERC20SpendSessionRequest(address ercAddress, uint amount, address sessionContract, bytes4 functionSelector) internal pure returns (SessionCallsStructs.SessionRequest memory) {
+    function createERC20SpendSessionRequest(address _ercAddress, uint _amount, address _sessionContract, bytes4 _functionSelector) internal pure returns (SessionCallsStructs.SessionRequest memory) {
         SessionCallsStructs.SessionRequest_ContractFunctionSelectors[] memory selectors =
             new SessionCallsStructs.SessionRequest_ContractFunctionSelectors[](1);
         bytes4[] memory functions = new bytes4[](1);
-        functions[0] = functionSelector;
+        functions[0] = _functionSelector;
         selectors[0] = SessionCallsStructs.SessionRequest_ContractFunctionSelectors({
-            aContract: sessionContract,
+            aContract: _sessionContract,
             functionSelectors: functions
         });
         SessionCallsStructs.SessionRequest_ERC20Allowance[] memory erc20Allowances =
             new SessionCallsStructs.SessionRequest_ERC20Allowance[](1);
         erc20Allowances[0] = SessionCallsStructs.SessionRequest_ERC20Allowance({
-            erc20Contract: ercAddress,
-            allowance: amount
+            erc20Contract: _ercAddress,
+            allowance: _amount
         });
         return SessionCallsStructs.SessionRequest({
             nativeAllowance: 0,
@@ -76,10 +76,58 @@ abstract contract TestSessionUtilities is TestUtilities {
         });
     }
 
+    function createERC1155SpendSessionRequest(address _ercAddress, uint256 _tokenId, uint _amount, address _sessionContract, bytes4 _functionSelector) internal pure returns (SessionCallsStructs.SessionRequest memory) {
+        SessionCallsStructs.SessionRequest_ContractFunctionSelectors[] memory selectors =
+            new SessionCallsStructs.SessionRequest_ContractFunctionSelectors[](1);
+        selectors[0] = SessionCallsStructs.SessionRequest_ContractFunctionSelectors({
+            aContract: _sessionContract,
+            functionSelectors: asSingletonArray(_functionSelector)
+        });
+        SessionCallsStructs.SessionRequest_ERC1155Allowance[] memory erc1155Allowances =
+            new SessionCallsStructs.SessionRequest_ERC1155Allowance[](1);
+        erc1155Allowances[0] = SessionCallsStructs.SessionRequest_ERC1155Allowance({
+            erc1155Contract: _ercAddress,
+            approveAll: false,
+            tokenIds: asSingletonArray(_tokenId),
+            allowances: asSingletonArray(_amount)
+        });
+        return SessionCallsStructs.SessionRequest({
+            nativeAllowance: 0,
+            contractFunctionSelectors: selectors,
+            erc20Allowances: new SessionCallsStructs.SessionRequest_ERC20Allowance[](0),
+            erc721Allowances: new SessionCallsStructs.SessionRequest_ERC721Allowance[](0),
+            erc1155Allowances: erc1155Allowances
+        });
+    }
+
+    function createERC1155SpendSessionRequest(address _ercAddress, uint256[] memory _tokenIds, uint256[] memory _amounts, address _sessionContract, bytes4 _functionSelector) internal pure returns (SessionCallsStructs.SessionRequest memory) {
+        SessionCallsStructs.SessionRequest_ContractFunctionSelectors[] memory selectors =
+            new SessionCallsStructs.SessionRequest_ContractFunctionSelectors[](1);
+        selectors[0] = SessionCallsStructs.SessionRequest_ContractFunctionSelectors({
+            aContract: _sessionContract,
+            functionSelectors: asSingletonArray(_functionSelector)
+        });
+        SessionCallsStructs.SessionRequest_ERC1155Allowance[] memory erc1155Allowances =
+            new SessionCallsStructs.SessionRequest_ERC1155Allowance[](1);
+        erc1155Allowances[0] = SessionCallsStructs.SessionRequest_ERC1155Allowance({
+            erc1155Contract: _ercAddress,
+            approveAll: false,
+            tokenIds: _tokenIds,
+            allowances: _amounts
+        });
+        return SessionCallsStructs.SessionRequest({
+            nativeAllowance: 0,
+            contractFunctionSelectors: selectors,
+            erc20Allowances: new SessionCallsStructs.SessionRequest_ERC20Allowance[](0),
+            erc721Allowances: new SessionCallsStructs.SessionRequest_ERC721Allowance[](0),
+            erc1155Allowances: erc1155Allowances
+        });
+    }
+
     /**
      * @dev Assumes that each contract will invoke 1 function selector
      */
-    function createGasSpendSessionRequestMulti(uint amount, address[] memory sessionContracts, bytes4[] memory functionSelectors) internal pure returns (SessionCallsStructs.SessionRequest memory) {
+    function createGasSpendSessionRequestMulti(uint _amount, address[] memory sessionContracts, bytes4[] memory functionSelectors) internal pure returns (SessionCallsStructs.SessionRequest memory) {
         require(sessionContracts.length == functionSelectors.length, "Session contract function length mismatch");
         SessionCallsStructs.SessionRequest_ContractFunctionSelectors[] memory selectors =
             new SessionCallsStructs.SessionRequest_ContractFunctionSelectors[](sessionContracts.length);
@@ -92,7 +140,7 @@ abstract contract TestSessionUtilities is TestUtilities {
             });
         }
         return SessionCallsStructs.SessionRequest({
-            nativeAllowance: amount,
+            nativeAllowance: _amount,
             contractFunctionSelectors: selectors,
             erc20Allowances: new SessionCallsStructs.SessionRequest_ERC20Allowance[](0),
             erc721Allowances: new SessionCallsStructs.SessionRequest_ERC721Allowance[](0),

--- a/test/forge/utils/TestUtilities.sol
+++ b/test/forge/utils/TestUtilities.sol
@@ -185,4 +185,76 @@ abstract contract TestUtilities is Test {
     function signHashEthVRS(uint256 privateKey, bytes32 digest) internal pure returns (uint8 v, bytes32 r, bytes32 s) {
         (v, r, s) = vm.sign(privateKey, ECDSA.toEthSignedMessageHash(digest));
     }
+
+    function asSingletonArray(uint256 _item) internal pure returns (uint256[] memory array_) {
+        array_ = new uint256[](1);
+        array_[0] = _item;
+    }
+
+    function asSingletonArray(string memory _item) internal pure returns (string[] memory array_) {
+        array_ = new string[](1);
+        array_[0] = _item;
+    }
+
+    function asSingletonArray(bytes4 _item) internal pure returns (bytes4[] memory array_) {
+        array_ = new bytes4[](1);
+        array_[0] = _item;
+    }
+
+    function slice(bytes memory _bytes, uint _start, uint _length) internal pure returns (bytes memory) {
+        require(_bytes.length >= (_start + _length));
+
+        bytes memory tempBytes;
+
+        assembly {
+            switch iszero(_length)
+            case 0 {
+                // Get a location of some free memory and store it in tempBytes as
+                // Solidity does for memory variables.
+                tempBytes := mload(0x40)
+
+                // The first word of the slice result is potentially a partial
+                // word read from the original array. To read it, we calculate
+                // the length of that partial word and start copying that many
+                // bytes into the array. The first word we copy will start with
+                // data we don't care about, but the last `lengthmod` bytes will
+                // land at the beginning of the contents of the new array. When
+                // we're done copying, we overwrite the full first word with
+                // the actual length of the slice.
+                let lengthmod := and(_length, 31)
+
+                // The multiplication in the next line is necessary
+                // because when slicing multiples of 32 bytes (lengthmod == 0)
+                // the following copy loop was copying the origin's length
+                // and then ending prematurely not copying everything it should.
+                let mc := add(add(tempBytes, lengthmod), mul(0x20, iszero(lengthmod)))
+                let end := add(mc, _length)
+
+                for {
+                    // The multiplication in the next line has the same exact purpose
+                    // as the one above.
+                    let cc := add(add(add(_bytes, lengthmod), mul(0x20, iszero(lengthmod))), _start)
+                } lt(mc, end) {
+                    mc := add(mc, 0x20)
+                    cc := add(cc, 0x20)
+                } {
+                    mstore(mc, mload(cc))
+                }
+
+                mstore(tempBytes, _length)
+
+                //update free-memory pointer
+                //allocating the array padded to 32 bytes like the compiler does now
+                mstore(0x40, and(add(mc, 31), not(31)))
+            }
+            //if we want a zero-length slice let's just return a zero-length array
+            default {
+                tempBytes := mload(0x40)
+
+                mstore(0x40, add(tempBytes, 0x20))
+            }
+        }
+
+        return tempBytes;
+    }
 }


### PR DESCRIPTION
- Added ERC1155 transfer allowance tracking through account sessions.
- Refactored require statements into custom errors to reduce bytecode / improve test code hygiene
- Removed all state related to function selectors in favor of stored data at the bytecode level. This is needed for easy beacon upgrades, as the logic will be updated automatically without needing state update or migrations.
- Refactored ERC20 allowances to decode the transfer calls and validate / deduct allowances before the calls are made. This reduces reentry-type attack vectors.
- Refactored native token allowance deduction to be before the call to reduce reentry-type attack vectors.