### PR TITLE
feat: added erc721 session allowance support

### DIFF
--- a/contracts/modules/SessionCalls/SessionCallsStorage.sol
+++ b/contracts/modules/SessionCalls/SessionCallsStorage.sol
@@ -46,6 +46,7 @@ library SessionCallsStorage {
     error InvalidERC20TransferFunctionSelector(bytes4 functionSelector);
     error UnknownERC1155TransferFunction(bytes4 functionSelector);
     error InvalidStartingERC20BalancesLength(uint256 startingFungibleTokenBalancesLength);
+    error InsufficientAllowanceForERC721Transfer(address tokenAddress, uint256 tokenId);
     error InsufficientAllowanceForERC1155Transfer(address tokenAddress, uint256 tokenId, uint256 amount, uint256 allowance);
     error InsufficientAllowanceForERC20Transfer(address tokenAddress, uint256 amount, uint256 allowance);
 }

--- a/test/forge/SessionCalls.t.sol
+++ b/test/forge/SessionCalls.t.sol
@@ -8,12 +8,17 @@ import { SessionCalls, Calls, SessionCallsStorage } from "contracts/modules/Sess
 
 import { ERC20MockDecimals } from "test/forge/mocks/ERC20MockDecimals.sol";
 import { ERC1155Mock } from "test/forge/mocks/ERC1155Mock.sol";
+import { ERC721Mock } from "test/forge/mocks/ERC721Mock.sol";
 import { ERC1155Holder, ERC1155Receiver } from "@openzeppelin/contracts/token/ERC1155/utils/ERC1155Holder.sol";
+import { ERC721Holder } from "@openzeppelin/contracts/token/ERC721/utils/ERC721Holder.sol";
 import { IERC1155 } from "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
+import { IERC721 } from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 import "forge-std/console.sol";
 
-contract SessionCallsImpl is SessionCalls, ERC1155Holder {
+contract SessionCallsImpl is SessionCalls, ERC1155Holder, ERC721Holder {
     bool public didSomething;
 
     function initialize(address _controller) public initializer {
@@ -31,7 +36,7 @@ contract SessionCallsImpl is SessionCalls, ERC1155Holder {
     }
 }
 
-contract RandomContract is ERC1155Holder {
+contract RandomContract is ERC1155Holder, ERC721Holder {
     uint256 public count;
     uint256 public countToken;
 
@@ -52,14 +57,28 @@ contract RandomContract is ERC1155Holder {
         countToken += _amount;
         ERC1155Mock(_ercAddress).safeTransferFrom(msg.sender, address(this), _tokenId, _amount, "");
     }
+
+    function transferERC721(address _ercAddress, uint256 _tokenId) public {
+        countToken += 1;
+        ERC721Mock(_ercAddress).safeTransferFrom(msg.sender, address(this), _tokenId);
+    }
+
+    function transferERC721To(address _ercAddress, uint256 _tokenId, address _to) public {
+        countToken += 1;
+        ERC721Mock(_ercAddress).safeTransferFrom(address(this), _to, _tokenId);
+    }
 }
 
 contract SessionCallsTest is TestBase {
+    bytes4 private constant SAFE_TRANSFER_FROM_SELECTOR1 = bytes4(keccak256("safeTransferFrom(address,address,uint256)"));
+    bytes4 private constant SAFE_TRANSFER_FROM_SELECTOR2 = bytes4(keccak256("safeTransferFrom(address,address,uint256,bytes)"));
+
     SessionCallsImpl _calls;
     RandomContract _contract;
 
     ERC20MockDecimals _erc20 = new ERC20MockDecimals(18);
     ERC1155Mock _erc1155 = new ERC1155Mock();
+    ERC721Mock _erc721 = new ERC721Mock();
 
     uint256 internal nonceCur = 0;
 
@@ -446,6 +465,55 @@ contract SessionCallsTest is TestBase {
         assertEq(2 ether, _erc20.balanceOf(leet));
     }
 
+    function testCouldBeERC20() public {
+        debug("Is ERC20: ", _couldBeERC20(address(_erc20)));
+        _erc20.mint(deployer, 10 ether);
+        debug("Is ERC20: ", _couldBeERC20(address(_erc20)));
+        debug("Is deployer ERC20: ", _couldBeERC20(address(this)));
+        debug("Is leet ERC20: ", _couldBeERC20(leet));
+    }
+
+    function balanceOf(address) public pure returns(uint256) {
+        return 0;
+    }
+
+    function totalSupply() public pure returns(uint256) {
+        return 0;
+    }
+
+    function supportsInterface(bytes4 interfaceId) public pure returns (bool) {
+        return interfaceId == type(IERC721).interfaceId;
+    }
+
+    function _couldBeERC20(address _targetContract) private view returns(bool couldBeERC20_) {
+        (bool _success, bytes memory _returnData) = _targetContract.staticcall(abi.encodeCall(IERC20.balanceOf, (address(this))));
+        couldBeERC20_ = _success && _returnData.length == 32;
+        if(couldBeERC20_) {
+            // If the contract has balanceOf AND totalSupply, it's definitely a token contract of some sort.
+            (_success, _returnData) = _targetContract.staticcall(abi.encodeCall(IERC20.totalSupply, ()));
+            couldBeERC20_ = _success && _returnData.length == 32;
+            if(couldBeERC20_) {
+                // If the contract has balanceOf AND totalSupply, and does not support ERC721/ERC1155, it's likely an ERC20
+                if(_supportsInterface(_targetContract, type(IERC721).interfaceId)) {
+                    return false; // If it supports ERC721, it's not an ERC20
+                }
+                if(_supportsInterface(_targetContract, type(IERC1155).interfaceId)) {
+                    return false; // If it supports ERC1155, it's not an ERC20
+                }
+            }
+        }
+    }
+
+    /**
+     * @dev Will not revert if called against a non-contract or contract that does not implement ERC165.
+     * @param _targetContract The contract to check.
+     * @param _interfaceId The interface to check for support.
+     */
+    function _supportsInterface(address _targetContract, bytes4 _interfaceId) private view returns (bool isSupported_) {
+        (bool _success,bytes memory _returnData) = _targetContract.staticcall(abi.encodeCall(IERC165.supportsInterface, (_interfaceId)));
+        isSupported_ = _success && abi.decode(_returnData, (bool));
+    }
+
     /**
      * ERC1155 Session Tests
      */
@@ -471,7 +539,7 @@ contract SessionCallsTest is TestBase {
         CallsStructs.CallRequest memory _callReq = CallsStructs.CallRequest({
             target: address(_erc1155),
             value: 0,
-            data: abi.encodeWithSelector(ERC1155Mock.safeTransferFrom.selector, address(_calls), leet, _testTokenId, 2, ""),
+            data: abi.encodeCall(ERC1155Mock.safeTransferFrom, (address(_calls), leet, _testTokenId, 2, "")),
             nonce: ++nonceCur
         });
 
@@ -584,5 +652,222 @@ contract SessionCallsTest is TestBase {
 
         assertEq(6, _erc1155.balanceOf(address(_calls), _testTokenId));
         assertEq(4, _erc1155.balanceOf(address(_contract), _testTokenId));
+    }
+
+    /**
+     * ERC721 Session Tests
+     */
+
+    function testAllowERC721TransferDirect() public {
+        uint256 _testTokenId = 12345;
+        _erc721.mint(address(_calls), _testTokenId);
+
+        // transferFrom session test
+        startSession(
+            address(_calls),
+            signingPK,
+            leet,
+            createERC721TransferSessionRequest(
+                address(_erc721), _testTokenId, address(_erc721), ERC721Mock.transferFrom.selector
+            ),
+            (block.timestamp + 1 days),
+            ++nonceCur
+        );
+
+        assertEq(address(_calls), _erc721.ownerOf(_testTokenId));
+
+        CallsStructs.CallRequest memory _callReq = CallsStructs.CallRequest({
+            target: address(_erc721),
+            value: 0,
+            data: abi.encodeCall(ERC721Mock.transferFrom, (address(_calls), leet, _testTokenId)),
+            nonce: ++nonceCur
+        });
+
+        // Call transferFrom
+        vm.prank(leet);
+        _calls.sessionCall(_callReq);
+
+        assertEq(leet, _erc721.ownerOf(_testTokenId));
+
+        // Try to call transferFrom again without required allowance and without the token
+        vm.prank(leet);
+        vm.expectRevert(abi.encodeWithSelector(
+            SessionCallsStorage.InsufficientAllowanceForERC721Transfer.selector,
+            address(_erc721),
+            _testTokenId
+        ));
+        _calls.sessionCall(_callReq);
+
+        assertEq(leet, _erc721.ownerOf(_testTokenId));
+
+        vm.prank(leet);
+        _erc721.transferFrom(leet, address(_calls), _testTokenId);
+
+        assertEq(address(_calls), _erc721.ownerOf(_testTokenId));
+
+        // Try to call transferFrom again without required allowance and with the token
+        vm.prank(leet);
+        vm.expectRevert(abi.encodeWithSelector(
+            SessionCallsStorage.InsufficientAllowanceForERC721Transfer.selector,
+            address(_erc721),
+            _testTokenId
+        ));
+        _calls.sessionCall(_callReq);
+
+        // safeTransferFrom (no bytes parameter - SAFE_TRANSFER_FROM_SELECTOR1) session test
+        startSession(
+            address(_calls),
+            signingPK,
+            leet,
+            createERC721TransferSessionRequest(
+                address(_erc721), _testTokenId, address(_erc721), SAFE_TRANSFER_FROM_SELECTOR1
+            ),
+            (block.timestamp + 1 days),
+            ++nonceCur
+        );
+
+        assertEq(address(_calls), _erc721.ownerOf(_testTokenId));
+
+        _callReq = CallsStructs.CallRequest({
+            target: address(_erc721),
+            value: 0,
+            data: abi.encodeWithSelector(SAFE_TRANSFER_FROM_SELECTOR1, address(_calls), leet, _testTokenId),
+            nonce: ++nonceCur
+        });
+
+        // Call safeTransferFrom
+        vm.prank(leet);
+        _calls.sessionCall(_callReq);
+
+        assertEq(leet, _erc721.ownerOf(_testTokenId));
+
+        // Try to call safeTransferFrom again without required allowance and without the token
+        vm.prank(leet);
+        vm.expectRevert(abi.encodeWithSelector(
+            SessionCallsStorage.InsufficientAllowanceForERC721Transfer.selector,
+            address(_erc721),
+            _testTokenId
+        ));
+        _calls.sessionCall(_callReq);
+
+        assertEq(leet, _erc721.ownerOf(_testTokenId));
+
+        vm.prank(leet);
+        _erc721.transferFrom(leet, address(_calls), _testTokenId);
+
+        assertEq(address(_calls), _erc721.ownerOf(_testTokenId));
+
+        // Try to call safeTransferFrom again without required allowance and with the token
+        vm.prank(leet);
+        vm.expectRevert(abi.encodeWithSelector(
+            SessionCallsStorage.InsufficientAllowanceForERC721Transfer.selector,
+            address(_erc721),
+            _testTokenId
+        ));
+        _calls.sessionCall(_callReq);
+
+        // safeTransferFrom (with bytes parameter - SAFE_TRANSFER_FROM_SELECTOR2) session test
+        startSession(
+            address(_calls),
+            signingPK,
+            leet,
+            createERC721TransferSessionRequest(
+                address(_erc721), _testTokenId, address(_erc721), SAFE_TRANSFER_FROM_SELECTOR2
+            ),
+            (block.timestamp + 1 days),
+            ++nonceCur
+        );
+
+        assertEq(address(_calls), _erc721.ownerOf(_testTokenId));
+
+        _callReq = CallsStructs.CallRequest({
+            target: address(_erc721),
+            value: 0,
+            data: abi.encodeWithSelector(SAFE_TRANSFER_FROM_SELECTOR2, address(_calls), leet, _testTokenId, ""),
+            nonce: ++nonceCur
+        });
+
+        // Call safeTransferFrom
+        vm.prank(leet);
+        _calls.sessionCall(_callReq);
+
+        assertEq(leet, _erc721.ownerOf(_testTokenId));
+
+        // Try to call safeTransferFrom again without required allowance and without the token
+        vm.prank(leet);
+        vm.expectRevert(abi.encodeWithSelector(
+            SessionCallsStorage.InsufficientAllowanceForERC721Transfer.selector,
+            address(_erc721),
+            _testTokenId
+        ));
+        _calls.sessionCall(_callReq);
+
+        assertEq(leet, _erc721.ownerOf(_testTokenId));
+
+        vm.prank(leet);
+        _erc721.transferFrom(leet, address(_calls), _testTokenId);
+
+        assertEq(address(_calls), _erc721.ownerOf(_testTokenId));
+
+        // Try to call safeTransferFrom again without required allowance and with the token
+        vm.prank(leet);
+        vm.expectRevert(abi.encodeWithSelector(
+            SessionCallsStorage.InsufficientAllowanceForERC721Transfer.selector,
+            address(_erc721),
+            _testTokenId
+        ));
+        _calls.sessionCall(_callReq);
+    }
+
+    function testAllowERC721TransferThroughOtherContract() public {
+        uint256 _testTokenId = 12345;
+        _erc721.mint(address(_calls), _testTokenId);
+
+        startSession(
+            address(_calls),
+            signingPK,
+            leet,
+            createRestrictedSessionRequest(address(_erc721), ERC721Mock.setApprovalForAll.selector),
+            (block.timestamp + 1 days),
+            ++nonceCur
+        );
+        CallsStructs.CallRequest memory _callReq = CallsStructs.CallRequest({
+            target: address(_erc721),
+            value: 0,
+            data: abi.encodeCall(ERC721Mock.setApprovalForAll, (address(_contract), true)),
+            nonce: ++nonceCur
+        });
+        vm.prank(leet);
+        _calls.sessionCall(_callReq);
+
+        startSession(
+            address(_calls),
+            signingPK,
+            leet,
+            createRestrictedSessionRequest(address(_contract), RandomContract.transferERC721.selector),
+            (block.timestamp + 1 days),
+            ++nonceCur
+        );
+
+        assertEq(address(_calls), _erc721.ownerOf(_testTokenId));
+
+        _callReq = CallsStructs.CallRequest({
+            target: address(_contract),
+            value: 0,
+            data: abi.encodeCall(RandomContract.transferERC721, (address(_erc721), _testTokenId)),
+            nonce: ++nonceCur
+        });
+        vm.prank(leet);
+        _calls.sessionCall(_callReq);
+
+        assertEq(address(_contract), _erc721.ownerOf(_testTokenId));
+
+        _contract.transferERC721To(address(_erc721), _testTokenId, address(_calls));
+
+        // Multiple calls in the same session should be allowed
+        vm.prank(leet);
+        _calls.sessionCall(_callReq);
+
+        assertEq(address(_contract), _erc721.ownerOf(_testTokenId));
     }
 }

--- a/test/forge/mocks/ERC1155Mock.sol
+++ b/test/forge/mocks/ERC1155Mock.sol
@@ -9,9 +9,12 @@ import { ERC1155 } from "@openzeppelin/contracts/token/ERC1155/ERC1155.sol";
 contract ERC1155Mock is ERC1155 {
     constructor() ERC1155("www.example.come") { }
 
-    /// @dev Mint _amount to _to.
-    /// @param _to The address that will receive the mint
-    /// @param _amount The amount to be minted
+    /**
+     * @dev Mint _amount of the _tokenId to _to.
+     * @param _to The address that will receive the mint
+     * @param _tokenId The tokenId to be minted
+     * @param _amount The amount to be minted
+     */
     function mint(address _to, uint256 _tokenId, uint256 _amount) external {
         _mint(_to, _tokenId, _amount, "");
     }

--- a/test/forge/mocks/ERC721Mock.sol
+++ b/test/forge/mocks/ERC721Mock.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import { ERC721 } from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+
+/// @title ERC721MockDecimals
+/// @dev ONLY FOR TESTS
+contract ERC721Mock is ERC721 {
+    constructor() ERC721("MOCKNAME", "MSYMBL") { }
+
+    /**
+     * @dev Mint the _tokenId to _to.
+     * @param _to The address that will receive the mint
+     * @param _tokenId The tokenId to be minted
+     */
+    function mint(address _to, uint256 _tokenId) external {
+        _mint(_to, _tokenId);
+    }
+
+    /**
+     * @dev needed to reference function selector as ERC721Mock.transferFrom.selector
+     */
+    function transferFrom(
+        address from,
+        address to,
+        uint256 id
+    ) public virtual override {
+        super.transferFrom(from, to, id);
+    }
+
+    /**
+     * @dev needed to reference function selector as ERC721Mock.setApprovalForAll.selector
+     */
+    function setApprovalForAll(address operator, bool approved) public virtual override {
+        super.setApprovalForAll(operator, approved);
+    }
+}

--- a/test/forge/utils/TestSessionUtilities.sol
+++ b/test/forge/utils/TestSessionUtilities.sol
@@ -124,6 +124,29 @@ abstract contract TestSessionUtilities is TestUtilities {
         });
     }
 
+    function createERC721TransferSessionRequest(address _ercAddress, uint256 _tokenId, address _sessionContract, bytes4 _functionSelector) internal pure returns (SessionCallsStructs.SessionRequest memory) {
+        SessionCallsStructs.SessionRequest_ContractFunctionSelectors[] memory selectors =
+            new SessionCallsStructs.SessionRequest_ContractFunctionSelectors[](1);
+        selectors[0] = SessionCallsStructs.SessionRequest_ContractFunctionSelectors({
+            aContract: _sessionContract,
+            functionSelectors: asSingletonArray(_functionSelector)
+        });
+        SessionCallsStructs.SessionRequest_ERC721Allowance[] memory erc721Allowances =
+            new SessionCallsStructs.SessionRequest_ERC721Allowance[](1);
+        erc721Allowances[0] = SessionCallsStructs.SessionRequest_ERC721Allowance({
+            erc721Contract: _ercAddress,
+            approveAll: false,
+            tokenIds: asSingletonArray(_tokenId)
+        });
+        return SessionCallsStructs.SessionRequest({
+            nativeAllowance: 0,
+            contractFunctionSelectors: selectors,
+            erc20Allowances: new SessionCallsStructs.SessionRequest_ERC20Allowance[](0),
+            erc721Allowances: erc721Allowances,
+            erc1155Allowances: new SessionCallsStructs.SessionRequest_ERC1155Allowance[](0)
+        });
+    }
+
     /**
      * @dev Assumes that each contract will invoke 1 function selector
      */


### PR DESCRIPTION
- Added erc721 token allowance tracking for sessions w/ extensive tests.
- Fixed issue where different standards with the same function selectors were trying to unintentionally deduct tokens.

NOTE: Since ERC20s don't implement ERC165's supportInterface standard, a workaround to detect erc20 contract addresses was added. In the event that a detection gives a false positive, the session will need artificial allowances (meaning contracts that are mistakenly identified as erc20s will always revert). If an ERC20 contract does not implement totalSupply or balanceOf, we will not detect them as an erc20 and they will not be subject to session allowances. This is an accepted shortcoming, as many dApps/protocols would be unable to identify these contracts successfully and may not wish to.